### PR TITLE
Deprecated unnecessary build

### DIFF
--- a/tf_deploy_bellanov/main.tf
+++ b/tf_deploy_bellanov/main.tf
@@ -123,13 +123,6 @@ locals {
   }
 
   builds = {
-    "cloudcdn-poc" : {
-      "repository" : "cloudcdn-poc",
-      "filename" : "build.yaml",
-      "description" : "Cloud CDN PoC.",
-      "owner" : local.build_config.owner,
-      "tag" : ".*"
-    },
     "cloudrun-poc-editor" : {
       "repository" : "cloudrun-poc-editor",
       "filename" : "build.yaml",


### PR DESCRIPTION
In this PR, the **cloudcdn** repository is being deprecated due to no longer being required.