### PR TITLE
Updated go-template artifact to version 0.2.2

### DIFF
--- a/tf_deploy_bellanov/main.tf
+++ b/tf_deploy_bellanov/main.tf
@@ -172,7 +172,7 @@ locals {
     "dev" : {
       "cloud_run_jobs": {
         "go-template" : {
-          "image" : "us-central1-docker.pkg.dev/${local.project}/docker-releases/go-template:0.1.0"
+          "image" : "us-central1-docker.pkg.dev/${local.project}/docker-releases/go-template:0.2.2"
         }
       },
       "cloud_run_services" : {


### PR DESCRIPTION
In this PR, the go-template job was updated to use artifact version 0.2.2.