### PR TITLE
Added Google application default scripts

### DIFF
--- a/scripts/application_default_credentials.sh
+++ b/scripts/application_default_credentials.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Generate application default credentials.
+
+gcloud auth application-default login
+
+# Revoke credentials upon completion
+# 
+# Configuration Location: ~/.config/gcloud/application_default_credentials.json
+# gcloud auth application-default revoke

--- a/scripts/revoke_default_credentials.sh
+++ b/scripts/revoke_default_credentials.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# Revoke and disable application default credentials (~/.config/gcloud/application_default_credentials.json).
+
+gcloud auth application-default revoke


### PR DESCRIPTION
In this PR, scripts were added to make it easier to both authenticate and revoke the Google Application Default Credentials.